### PR TITLE
Fix for broken utf-8 loaded from weechat option

### DIFF
--- a/foo_spam.pl
+++ b/foo_spam.pl
@@ -1158,7 +1158,7 @@ if (HAVE_IRSSI) {
 } elsif (HAVE_WEECH) {
 	*print_now_playing = sub {
 		my ( $data, $buffer, @args ) = @_;
-		$format   = weechat::config_get_plugin("format");
+		$format   = decode("UTF-8", weechat::config_get_plugin("format"));
 		$player   = lc(weechat::config_get_plugin("player"));
 		$hostport = weechat::config_get_plugin("port");
 		$hostname = weechat::config_get_plugin("hostname");


### PR DESCRIPTION
If utf-8 is used in the format weechat option (for separators as an example) it didn't get decoded as utf-8 this could also be broken for other clients too? but I don't use any of those so idk :)
